### PR TITLE
alternatives to WebView:evaluate()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "lune-webview"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lune-webview"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/HighFlowey/lune-webview"

--- a/examples/custom_protocol.luau
+++ b/examples/custom_protocol.luau
@@ -1,17 +1,27 @@
 local wry = require("@luneweb/wry")
 local window, handle = wry.create_window({}), nil
 
-wry.create_webview(window, {
-	custom_protocol_name = "lune",
-	custom_protocol_handler = function(_req)
-		return {
-			body = "Hey!",
-			headers = {
-				["Access-Control-Allow-Origin"] = "*",
-				["Access-Control-Allow-Headers"] = "*",
-			},
-		}
-	end,
+local webview = wry.create_webview(window, {
+	custom_protocols = {
+		lune = function(_req)
+			return {
+				body = "Hey (1)!",
+				headers = {
+					["Access-Control-Allow-Origin"] = "*",
+					["Access-Control-Allow-Headers"] = "*",
+				},
+			}
+		end,
+		luneweb = function(_req)
+			return {
+				body = "Hey (2)!",
+				headers = {
+					["Access-Control-Allow-Origin"] = "*",
+					["Access-Control-Allow-Headers"] = "*",
+				},
+			}
+		end,
+	},
 	url = "http://lune.app/",
 })
 
@@ -23,3 +33,7 @@ handle = wry.event_loop(window, function(msg)
 end)
 
 wry.run()
+
+require("@luneweb/task").wait(2)
+
+webview:load_url("http://luneweb.app/")

--- a/lib/webview.luau
+++ b/lib/webview.luau
@@ -31,11 +31,19 @@
 	@method evaluate_noresult
 	@within WebView
 
-	Similar to `WebView:evaluate(...)`, but does not yield to return results
-	
-	### Use Cases
-	* Just wanting to run code through webview without wanting the last statement to be returned as lua value
-	* Wanting to run code while `WebView` is getting response from a url to load a page (using evaluate in that case will yield forever unless you do it inside a new task, e.g. task.spawn(...))
+	Similar to `WebView:evaluate(...)`, but does not yield and does not return any result
+
+	@param script string
+]=]
+
+--[=[
+	@method evaluate_callback
+	@within WebView
+
+	Similar to `WebView:evaluate(...)`, but instead of yielding to return result, it passes the result to the callback function
+
+	@param script string
+	@param callback (result: unknown) -> ()
 ]=]
 
 --[=[
@@ -46,7 +54,7 @@
 	Runs the provided javascript code through the webview and returns the last statement as a lua value
 
 	### Bug(s)
-	* Will yield forever if you run it while `WebView` is getting response from a url to load a page, unless you do it inside task.spawn(...) or use `WebView:evaluate_noresult(...)` instead
+	* Will yield forever if you run it while custom protocol is sending response to webview for **loading a page**
 
 	### Example
 

--- a/lib/webview.luau
+++ b/lib/webview.luau
@@ -28,11 +28,25 @@
 ]=]
 
 --[=[
+	@method evaluate_noresult
+	@within WebView
+
+	Similar to `WebView:evaluate(...)`, but does not yield to return results
+	
+	### Use Cases
+	* Just wanting to run code through webview without wanting the last statement to be returned as lua value
+	* Wanting to run code while `WebView` is getting response from a url to load a page (using evaluate in that case will yield forever unless you do it inside a new task, e.g. task.spawn(...))
+]=]
+
+--[=[
 	@yields
 	@method evaluate
 	@within WebView
 
 	Runs the provided javascript code through the webview and returns the last statement as a lua value
+
+	### Bug(s)
+	* Will yield forever if you run it while `WebView` is getting response from a url to load a page, unless you do it inside task.spawn(...) or use `WebView:evaluate_noresult(...)` instead
 
 	### Example
 

--- a/lib/webview.luau
+++ b/lib/webview.luau
@@ -5,14 +5,15 @@
 
 	```lua
 	local webview = Wry.create_webview(window, {
-		custom_protocol_name = "lune",
-		custom_protocol_handler = function(request)
-			if request.path == "/print" then
-				print("Hello, Lune!")
-			end
+		custom_protocols = {
+			lune = function(request)
+				if request.path == "/print" then
+					print("Hello, Lune!")
+				end
 
-			return "Hello, Lune!"
-		end,
+				return "Hello, Lune!"
+			end,
+		},
 		url = "http://lune.app/"
 	})
 

--- a/lib/window.luau
+++ b/lib/window.luau
@@ -38,7 +38,7 @@
 
 	* Does not account for elements in the webview
 
-	## WebView alternative
+	### WebView alternative
 
 	```lua
 	local size: Dimension = window.webview:evaluate("{ x: window.innerWidth, y: window.innerHeight }")

--- a/lib/wry.luau
+++ b/lib/wry.luau
@@ -14,14 +14,9 @@
 		title = "Hello, Lune!"
 	})
 
-	Wry.create_webview(window, {
-		html = "<h1>Hello, Lune!</h1>"
-	})
-
 	local handle
 	handle = Wry.event_loop(window, function(msg)
 		if msg == Wry.events.CloseRequested then
-			window:close()
 			handle.stop()
 		end
 	end)
@@ -51,6 +46,14 @@
 
 	@param config WindowConfig
 	@return Window
+
+	## Example
+
+	```lua
+	local window = Wry.create_window({
+		title = "Hello, Lune!"
+	})
+	```
 ]=]
 
 --[=[
@@ -73,8 +76,7 @@
 	.html string?
 	.url string?
 	.headers WebViewHeaders? -- ! having more than 1 header value will error
-	.custom_protocol_name string?
-	.custom_protocol_handler HttpHandler?
+	.custom_protocols { [string]: HttpHandler }?
 ]=]
 
 --[=[
@@ -83,6 +85,14 @@
 
 	@param config WebViewConfig
 	@return WebView
+
+	## Example
+
+	```lua
+	Wry.create_webview(window, {
+		html = "<h1>Hello, Lune!</h1>"
+	})
+	```
 ]=]
 
 --[=[

--- a/lib/wry.luau
+++ b/lib/wry.luau
@@ -72,6 +72,7 @@
 --[=[
 	@interface WebViewConfig
 	@within Wry
+	.with_devtools boolean?
 	.init_script string?
 	.html string?
 	.url string?

--- a/src/lune/builtins/wry/mod.rs
+++ b/src/lune/builtins/wry/mod.rs
@@ -152,7 +152,7 @@ pub async fn winit_run(lua: &Lua, _: ()) -> LuaResult<()> {
             });
 
             if !EVENT_LOOP_SENDER.is_closed() {
-                EVENT_LOOP_SENDER.send(message).unwrap();
+                EVENT_LOOP_SENDER.send(message).into_lua_err().unwrap();
             } else {
                 break;
             }
@@ -231,6 +231,7 @@ pub async fn winit_event_loop<'lua>(
             inner_lua
                 .as_ref()
                 .push_thread_back(thread, message.1)
+                .into_lua_err()
                 .unwrap();
 
             tokio::time::sleep(Duration::ZERO).await;
@@ -243,7 +244,7 @@ pub async fn winit_event_loop<'lua>(
                 return Ok(());
             }
 
-            shutdown_tx.send(true).unwrap();
+            shutdown_tx.send(true).into_lua_err()?;
             Ok(())
         })?
         .build_readonly()

--- a/src/lune/builtins/wry/webview/config.rs
+++ b/src/lune/builtins/wry/webview/config.rs
@@ -16,6 +16,13 @@ pub struct LuaWebView {
 
 impl LuaUserData for LuaWebView {
     fn add_methods<'lua, M: LuaUserDataMethods<'lua, Self>>(methods: &mut M) {
+        methods.add_method(
+            "evaluate_noresult",
+            |_lua: &Lua, this: &Self, script: String| {
+                this.webview.evaluate_script(script.as_str()).into_lua_err()
+            },
+        );
+
         methods.add_async_method(
             "evaluate",
             |lua: &Lua, this: &Self, script: String| async move {

--- a/src/lune/builtins/wry/webview/config.rs
+++ b/src/lune/builtins/wry/webview/config.rs
@@ -112,6 +112,7 @@ impl LuaUserData for LuaWebView {
 
 // LuaWebViewConfig
 pub struct LuaWebViewConfig {
+    pub with_devtools: bool,
     pub init_script: Option<String>,
     pub html: Option<String>,
     pub url: Option<String>,
@@ -123,6 +124,7 @@ impl<'lua> FromLua<'lua> for LuaWebViewConfig {
     fn from_lua(value: LuaValue<'lua>, lua: &'lua Lua) -> LuaResult<Self> {
         if let Some(config) = value.as_table() {
             Ok(Self {
+                with_devtools: config.get("with_devtools").unwrap_or(false),
                 init_script: config.get("init_script").ok(),
                 html: config.get("html").ok(),
                 url: config.get("url").ok(),

--- a/src/lune/builtins/wry/webview/mod.rs
+++ b/src/lune/builtins/wry/webview/mod.rs
@@ -36,23 +36,14 @@ pub fn create<'lua>(
             webview_builder = webview_builder.with_url_and_headers(url, config.headers);
         }
 
-        let incomplete_custom_protocol_config = {
-            (config.custom_protocol_name.is_some() & config.custom_protocol_handler.is_none())
-                | (config.custom_protocol_name.is_none() & config.custom_protocol_handler.is_some())
-        };
-
-        if incomplete_custom_protocol_config {
-            return Err(LuaError::RuntimeError("config for custom_protocol is incomplete, both custom_protocol_name and custom_protocol_handler must be present".into()));
-        }
-
-        if let Some(custom_protocol_name) = config.custom_protocol_name {
-            let custom_protocol_fn_key = Rc::new(config.custom_protocol_handler.unwrap());
-
+        for (custom_protocol_name, custom_protocol_fn_key) in config.custom_protocols {
             let inner_lua = lua
                 .app_data_ref::<Weak<Lua>>()
                 .expect("Missing weak lua ref")
                 .upgrade()
                 .expect("Lua was dropped unexpectedly");
+
+            let custom_protocol_fn_key = Rc::new(custom_protocol_fn_key);
 
             webview_builder = webview_builder.with_asynchronous_custom_protocol(
                 custom_protocol_name,

--- a/src/lune/builtins/wry/webview/mod.rs
+++ b/src/lune/builtins/wry/webview/mod.rs
@@ -76,10 +76,13 @@ pub fn create<'lua>(
 
                         let lua_res_table =
                             outter_lua.get_thread_result(thread_id).unwrap().unwrap();
-                        let lua_res =
-                            LuaResponse::from_lua_multi(lua_res_table, &outter_lua).unwrap();
+                        let lua_res = LuaResponse::from_lua_multi(lua_res_table, &outter_lua);
 
-                        responder.respond(lua_res.into_response2().unwrap());
+                        if let Ok(lua_res) = lua_res {
+                            responder.respond(lua_res.into_response2().unwrap());
+                        } else {
+                            panic!("Couldn't get lua response from custom_protocol")
+                        }
                     });
                 },
             );

--- a/src/lune/builtins/wry/webview/mod.rs
+++ b/src/lune/builtins/wry/webview/mod.rs
@@ -24,7 +24,8 @@ pub fn create<'lua>(
     if let Some(window) = field1.as_userdata() {
         let mut window = window.borrow_mut::<LuaWindow>()?;
 
-        let mut webview_builder = WebViewBuilder::new(&window.window);
+        let mut webview_builder =
+            WebViewBuilder::new(&window.window).with_devtools(config.with_devtools);
 
         let mut init_script = LuaWebViewScript::new();
         init_script.write(JAVASCRIPT_API);

--- a/types/wry.luau
+++ b/types/wry.luau
@@ -26,6 +26,7 @@ export type WebView = {
 }
 
 export type WebViewConfig = {
+	with_devtools: boolean?,
 	init_script: string?,
 	html: string?,
 	url: string?,

--- a/types/wry.luau
+++ b/types/wry.luau
@@ -20,6 +20,7 @@ export type WindowConfig = {
 
 export type WebView = {
 	evaluate_noresult: (self: WebView, javascript: string) -> (),
+	evaluate_callback: (self: WebView, javascript: string, callback: (unknown) -> ()) -> (),
 	evaluate: (self: WebView, javascript: string) -> unknown,
 	ipc_handler: (self: WebView, callback: (message: unknown) -> ()) -> WebViewIPCHandle,
 	load_url: (self: WebView, url: string) -> (),

--- a/types/wry.luau
+++ b/types/wry.luau
@@ -19,6 +19,7 @@ export type WindowConfig = {
 }
 
 export type WebView = {
+	evaluate_noresult: (self: WebView, javascript: string) -> (),
 	evaluate: (self: WebView, javascript: string) -> unknown,
 	ipc_handler: (self: WebView, callback: (message: unknown) -> ()) -> WebViewIPCHandle,
 	load_url: (self: WebView, url: string) -> (),

--- a/types/wry.luau
+++ b/types/wry.luau
@@ -30,8 +30,7 @@ export type WebViewConfig = {
 	html: string?,
 	url: string?,
 	headers: { [string]: string }?,
-	custom_protocol_name: string?,
-	custom_protocol_handler: http.ServeHttpHandler?,
+	custom_protocols: { [string]: http.ServeHttpHandler }?,
 }
 
 export type WindowEvent = {


### PR DESCRIPTION
### Changes to WebViewConfig
* webview config now accepts multiple custom protocols, instead of one
* webview config now has an option for turning dev_tools on and off, which by default is always false

### Changes to WebView
* added evaluate_noresult(code: string) - doesn't yield and doesn't return the last statement in the javascript code
* added evaluate_callback(code: string, callback: (result: unknown) -> void) - doesn't yield and instead returns the last statement in the javascript code to the provided callback function

Also improved the documentation